### PR TITLE
:arrow_up: @1inch deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@eslint/compat": "1.1.0",
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^9.10.0",
-    "@1inch/tsconfig": "1.0.7",
+    "@1inch/tsconfig": "1.0.9",
     "@jest/globals": "29.7.0",
     "@swc/core": "1.5.25",
     "@swc/jest": "0.2.36",
@@ -41,8 +41,8 @@
     "node": "22.5.1"
   },
   "dependencies": {
-    "@1inch/byte-utils": "2.6.0",
-    "@1inch/cross-chain-sdk": "v0.1.15-rc.0",
+    "@1inch/byte-utils": "3.1.0",
+    "@1inch/cross-chain-sdk": "v0.2.1-rc.50",
     "dotenv": "16.4.5",
     "ethers": "6.13.2",
     "prool": "0.0.24"


### PR DESCRIPTION
### Context

adding lastest dependencies as `pnpm install` is failing on 

```
 ERR_PNPM_FETCH_401  GET https://npm.pkg.github.com/download/@1inch/cross-chain-sdk/0.1.15-rc.0/e1deae6506aa5386f007e76df7321d34ea3d46fe: Unauthorized - 401

No authorization header was set for the request.

These authorization settings were found:
@jsr:registry=https://npm.jsr.io/
//registry.npmjs.org/:_authToken=npm_[hidden]


 ERR_PNPM_FETCH_401  GET https://npm.pkg.github.com/download/@1inch/tsconfig/1.0.7/948920928f70c706075b76ee401fe1ab628a4a59: Unauthorized - 401
 
 
  ERR_PNPM_FETCH_401  GET https://npm.pkg.github.com/download/@1inch/byte-utils/2.6.0/e30bf56d722cd0982d2591f9ac3158b63bebeafa: Unauthorized - 401
```


I would also remove eslint as it has same problems

```
 ERR_PNPM_FETCH_401  GET https://npm.pkg.github.com/download/@1inch/eslint-config/3.0.7/5774b1fcbdb11e487651d358463f9976942cf482: Unauthorized - 401
```