### PR TITLE
Fix: resolve installation errors

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@1inch:registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Problem
When running `pnpm install`, users encounter 403 Forbidden errors for @1inch scoped packages:

```
ERR_PNPM_FETCH_403 GET https://npm.pkg.github.com/download/@1inch/limit-order-sdk/4.13.0/...: Forbidden - 403
```

## Root Cause
@1inch packages were trying to download from GitHub packages (`npm.pkg.github.com`) which requires authentication, even for public packages.

## Solution
Added `.npmrc` file that redirects all @1inch scoped packages to use the public npm registry instead of GitHub packages.

## Changes
- ✅ Add `.npmrc` file with `@1inch:registry=https://registry.npmjs.org/`
- ✅ No authentication required for package installation
- ✅ Resolves all 403 Forbidden errors for @1inch packages

## Testing
- Clone fresh repository
- Run `pnpm install` 
- Verify no 403 errors occur
- Confirm all dependencies install successfully

Issue fix: https://github.com/1inch/cross-chain-resolver-example/issues/4#issue-3265633753

