### PR TITLE
Fix: Lockfile now uses npm registry for @1inch/cross-chain-sdk

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,7 +119,7 @@ packages:
       assert: ^2.0.0
 
   '@1inch/cross-chain-sdk@0.1.15-rc.0':
-    resolution: {integrity: sha512-MYVF9vUTrxA/T3BGS5u/tpQWjLX2r1t/Ls3zz0t06lSfTGoAzCONFuGW/OfZ5olVAw+rHLK9k/t5sMt3jW/HGg==, tarball: https://npm.pkg.github.com/download/@1inch/cross-chain-sdk/0.1.15-rc.0/e1deae6506aa5386f007e76df7321d34ea3d46fe}
+    resolution: {integrity: sha512-MYVF9vUTrxA/T3BGS5u/tpQWjLX2r1t/Ls3zz0t06lSfTGoAzCONFuGW/OfZ5olVAw+rHLK9k/t5sMt3jW/HGg==, tarball: https://registry.npmjs.org/@1inch/cross-chain-sdk/-/cross-chain-sdk-0.1.15-rc.0.tgz}
     engines: {node: '>=18.16.0'}
     peerDependencies:
       assert: ^2.0.0


### PR DESCRIPTION

This pull request updates the pnpm-lock.yaml to ensure that the dependency @1inch/cross-chain-sdk@0.1.15-rc.0 is resolved from the npm registry (https://registry.npmjs.org) instead of GitHub Packages (https://npm.pkg.github.com).

### Problem
Currently, the lockfile points to a GitHub Packages -
```tarball: https://npm.pkg.github.com/download/@1inch/cross-chain-sdk/0.1.15-rc.0/e1deae6506aa5386f007e76df7321d34ea3d46fe```

This results in the following error for users without GitHub credentials:
```ERR_PNPM_FETCH_401: Unauthorized - 401```
This breaks `pnpm install` in environments without GitHub auth tokens and access to 1inch registry.

### Fix
The `tarball` entry was changed to:
```tarball: https://registry.npmjs.org/@1inch/cross-chain-sdk/-/cross-chain-sdk-0.1.15-rc.0.tgz```
This resolves the package directly from npmjs.org, avoiding auth errors and improving compatibility.